### PR TITLE
Support using any principal in keytab

### DIFF
--- a/flask_gssapi.py
+++ b/flask_gssapi.py
@@ -33,9 +33,10 @@ class GSSAPI(object):
             app.extensions = {}
 
         service_name = app.config.get('GSSAPI_SERVICE_NAME', 'HTTP')
-        hostname = app.config.get('GSSAPI_HOSTNAME', socket.getfqdn())
-        principal = '{}@{}'.format(service_name, hostname)
-        name = gssapi.Name(principal, gssapi.NameType.hostbased_service)
+        name = app.config.get('GSSAPI_HOSTNAME', socket.getfqdn())
+        if name is not None:
+            principal = '{}@{}'.format(service_name, name)
+            name = gssapi.Name(principal, gssapi.NameType.hostbased_service)
 
         app.extensions['gssapi'] = {
             'creds': gssapi.Credentials(name=name, usage='accept'),


### PR DESCRIPTION
Add support for GSS_C_NO_CREDENTIAL by allowing GSSAPI_HOSTNAME to be
set to None and passing it to gssapi.Credentials(). This makes it
possible to have multiple keytabs present in your keytab and it will use
the one that the client requests (which exists in the keytab.

Resolves #6