### PR TITLE
Accept raw Kerberos tokens

### DIFF
--- a/flask_gssapi.py
+++ b/flask_gssapi.py
@@ -78,16 +78,17 @@ class GSSAPI(object):
             def wrapper(*args, **kwargs):
                 """ Effective wrapper """
                 username, out_token = self.authenticate()
-                if username and out_token:
-                    b64_token = base64.b64encode(out_token).decode('utf-8')
-                    auth_data = 'Negotiate {0}'.format(b64_token)
+                if username:
                     if not users or username in users:
                         response = make_response(view_func(*args,
                                                            username=username,
                                                            **kwargs))
                     else:
                         response = Response(status=403)
-                    response.headers['WWW-Authenticate'] = auth_data
+                    if out_token:
+                        b64_token = base64.b64encode(out_token).decode('utf-8')
+                        auth_data = 'Negotiate {0}'.format(b64_token)
+                        response.headers['WWW-Authenticate'] = auth_data
                     return response
                 return Response(
                     status=401,

--- a/flask_gssapi.py
+++ b/flask_gssapi.py
@@ -57,7 +57,7 @@ class GSSAPI(object):
             out_token = ctx.step(in_token)
 
             if ctx.complete:
-                username = ctx._inquire(initiator_name=True).initiator_name
+                username = ctx.initiator_name
                 return str(username), out_token
 
         return None, None


### PR DESCRIPTION
Some clients send a plain Kerberos token instead of an SPNEGO token. Although python-gssapi accepts Kerberos, the authentication fails because the mechanism doesn't produce a final output token (like SPNEGO would).