### PR TITLE
Pass the username through request.environ

### DIFF
--- a/flask_gssapi.py
+++ b/flask_gssapi.py
@@ -62,11 +62,11 @@ class GSSAPI(object):
 
         return None, None
 
-    def require_auth(self):
+    def require_auth(self, *, username_arg='username'):
         """A decorator to protect views with Negotiate authentication."""
-        return self.require_user()
+        return self.require_user(username_arg=username_arg)
 
-    def require_user(self, *users, user=None):
+    def require_user(self, *users, user=None, username_arg='username'):
         """A decorator to protect views with Negotiate authentication."""
 
         # accept old-style single user keyword-argument as well
@@ -83,9 +83,9 @@ class GSSAPI(object):
                     auth_data = 'Negotiate {0}'.format(b64_token)
                     if not users or username in users:
                         request.environ['REMOTE_USER'] = username
-                        response = make_response(view_func(*args,
-                                                           username=username,
-                                                           **kwargs))
+                        if username_arg:
+                            kwargs[username_arg] = username
+                        response = make_response(view_func(*args, **kwargs))
                     else:
                         response = Response(status=403)
                     response.headers['WWW-Authenticate'] = auth_data

--- a/flask_gssapi.py
+++ b/flask_gssapi.py
@@ -82,6 +82,7 @@ class GSSAPI(object):
                     b64_token = base64.b64encode(out_token).decode('utf-8')
                     auth_data = 'Negotiate {0}'.format(b64_token)
                     if not users or username in users:
+                        request.environ['REMOTE_USER'] = username
                         response = make_response(view_func(*args,
                                                            username=username,
                                                            **kwargs))


### PR DESCRIPTION
It is sometimes useful to use the decorator for wrapping functions that come from other modules and do not expect a `username=` keyword arg.

At the same time, applications will often expect a `REMOTE_USER` environment item.