### PR TITLE
Fixed a TypeError: require_auth() in example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ Usage is fairly simple:
 
   # You can also get the username as a keyword argument
   @app.route('/another-secret')
-  @gssapi.require_auth
+  @gssapi.require_auth()
   def admin_view(username=''):
       return render_template('another-secret.html', username=username)
 


### PR DESCRIPTION
I firstly tried the example without parentheses ():

```python
@app.route("/")
@gssapi.require_auth
def index(username=''):
    return render_template('index.html', user=username)
```

however I was getting an error:
```
Traceback (most recent call last):
  File "/home/python3/venv/bin/flask", line 10, in <module>
    sys.exit(main())
  File "/home/python3/venv/lib/python3.7/site-packages/flask/cli.py", line 967, in
  main
    cli.main(args=sys.argv[1:], prog_name="python -m flask" if as_module else None)
  File "/home/python3/venv/lib/python3.7/site-packages/flask/cli.py", line 586, in
  main
    return super(FlaskGroup, self).main(*args, **kwargs)
  File "/home/python3/venv/lib/python3.7/site-packages/click/core.py", line 782, i
  n main
    rv = self.invoke(ctx)
  File "/home/python3/venv/lib/python3.7/site-packages/click/core.py", line 1259,
  in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/python3/venv/lib/python3.7/site-packages/click/core.py", line 1066,
  in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/python3/venv/lib/python3.7/site-packages/click/core.py", line 610, i
  n invoke
    return callback(*args, **kwargs)
  File "/home/python3/venv/lib/python3.7/site-packages/click/decorators.py", line
  73, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/python3/venv/lib/python3.7/site-packages/click/core.py", line 610, i
  n invoke
    return callback(*args, **kwargs)
  File "/home/python3/venv/lib/python3.7/site-packages/flask/cli.py", line 848, in
  run_command
    app = DispatchingApp(info.load_app, use_eager_loading=eager_loading)
  File "/home/python3/venv/lib/python3.7/site-packages/flask/cli.py", line 305, in
  __init__
    self._load_unlocked()
  File "/home/python3/venv/lib/python3.7/site-packages/flask/cli.py", line 330, in
  _load_unlocked
    self._app = rv = self.loader()
  File "/home/python3/venv/lib/python3.7/site-packages/flask/cli.py", line 388, in
  load_app
    app = locate_app(self, import_name, name)
  File "/home/python3/venv/lib/python3.7/site-packages/flask/cli.py", line 240, in
  locate_app
    __import__(module_name)
  File "/home/flask_gssapi_example/example.py", line 14, in <module>
    def index(username=''):
TypeError: require_auth() takes 1 positional argument but 2 were given
```
After changing the `@gssapi.require_auth` into `@gssapi.require_auth()` everything was okay.

```python
@app.route("/")
@gssapi.require_auth()
def index(username=''):
    return render_template('index.html', user=username)
```